### PR TITLE
Adjusting to add an option to avoid certificate checking when connecting using TLS

### DIFF
--- a/M2Mqtt/IMqttNetworkChannel.cs
+++ b/M2Mqtt/IMqttNetworkChannel.cs
@@ -29,6 +29,8 @@ namespace nanoFramework.M2Mqtt
 
         /// <summary>
         /// True to check the certificate when connecting using TLS.
+        /// Disabling this property will bypass the validation of the server root CA certificate.
+        /// Using the library this way it's unsecured and, therefore, not recommended.
         /// </summary>
         bool CertificateCheck { get; set; }
 

--- a/M2Mqtt/IMqttNetworkChannel.cs
+++ b/M2Mqtt/IMqttNetworkChannel.cs
@@ -28,6 +28,11 @@ namespace nanoFramework.M2Mqtt
         bool DataAvailable { get; }
 
         /// <summary>
+        /// True to check the certificate when connecting using TLS.
+        /// </summary>
+        bool CertificateCheck { get; set; }
+
+        /// <summary>
         /// Receive data from the network channel
         /// </summary>
         /// <param name="buffer">Data buffer for receiving data</param>

--- a/M2Mqtt/IMqttNetworkChannel.cs
+++ b/M2Mqtt/IMqttNetworkChannel.cs
@@ -32,7 +32,7 @@ namespace nanoFramework.M2Mqtt
         /// Disabling this property will bypass the validation of the server root CA certificate.
         /// Using the library this way it's unsecured and, therefore, not recommended.
         /// </summary>
-        bool CertificateCheck { get; set; }
+        bool ValidateServerCertificate { get; set; }
 
         /// <summary>
         /// Receive data from the network channel

--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -429,6 +429,8 @@ namespace nanoFramework.M2Mqtt
 
             try
             {
+                // Set the certificate check
+                _channel.CertificateCheck = _settings.CertificateCheck;
                 // connect to the broker
                 _channel.Connect();
             }

--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -430,7 +430,7 @@ namespace nanoFramework.M2Mqtt
             try
             {
                 // Set the certificate check
-                _channel.CertificateCheck = _settings.CertificateCheck;
+                _channel.ValidateServerCertificate = _settings.ValidateServerCertificate;
                 // connect to the broker
                 _channel.Connect();
             }

--- a/M2Mqtt/MqttSettings.cs
+++ b/M2Mqtt/MqttSettings.cs
@@ -99,6 +99,8 @@ namespace nanoFramework.M2Mqtt
         
         /// <summary>
         /// True to check the certificate when connection using TLS.
+        /// Disabling this property will bypass the validation of the server root CA certificate.
+        /// Using the library this way it's unsecured and, therefore, not recommended.
         /// </summary>
         public bool CertificateCheck { get; set; }
 

--- a/M2Mqtt/MqttSettings.cs
+++ b/M2Mqtt/MqttSettings.cs
@@ -98,11 +98,11 @@ namespace nanoFramework.M2Mqtt
         public int InflightQueueSize { get; set; }
         
         /// <summary>
-        /// True to check the certificate when connection using TLS.
+        /// True to check the server certificate when connection using TLS.
         /// Disabling this property will bypass the validation of the server root CA certificate.
         /// Using the library this way it's unsecured and, therefore, not recommended.
         /// </summary>
-        public bool CertificateCheck { get; set; }
+        public bool ValidateServerCertificate { get; set; }
 
         /// <summary>
         /// Singleton instance of settings
@@ -132,7 +132,7 @@ namespace nanoFramework.M2Mqtt
             DelayOnRetry = DefaultDelayRetry;
             TimeoutOnConnection = ConnectTimeout;
             InflightQueueSize = DefaultInflightQueueSize;
-            CertificateCheck = true;
+            ValidateServerCertificate = true;
         }
     }
 }

--- a/M2Mqtt/MqttSettings.cs
+++ b/M2Mqtt/MqttSettings.cs
@@ -98,6 +98,11 @@ namespace nanoFramework.M2Mqtt
         public int InflightQueueSize { get; set; }
         
         /// <summary>
+        /// True to check the certificate when connection using TLS.
+        /// </summary>
+        public bool CertificateCheck { get; set; }
+
+        /// <summary>
         /// Singleton instance of settings
         /// </summary>
         public static MqttSettings Instance
@@ -125,6 +130,7 @@ namespace nanoFramework.M2Mqtt
             DelayOnRetry = DefaultDelayRetry;
             TimeoutOnConnection = ConnectTimeout;
             InflightQueueSize = DefaultInflightQueueSize;
+            CertificateCheck = true;
         }
     }
 }

--- a/M2Mqtt/Net/MqttNetworkChannel.cs
+++ b/M2Mqtt/Net/MqttNetworkChannel.cs
@@ -72,6 +72,8 @@ namespace nanoFramework.M2Mqtt
 
         /// <summary>
         /// True to check the certificate when connecting using TLS.
+        /// Disabling this property will bypass the validation of the server root CA certificate.
+        /// Using the library this way it's unsecured and, therefore, not recommended.
         /// </summary>
         public bool CertificateCheck { get; set; } = true;
 

--- a/M2Mqtt/Net/MqttNetworkChannel.cs
+++ b/M2Mqtt/Net/MqttNetworkChannel.cs
@@ -70,6 +70,10 @@ namespace nanoFramework.M2Mqtt
         /// </summary>
         public bool DataAvailable => _secure ? _sslStream.DataAvailable : _socket.Available > 0;
 
+        /// <summary>
+        /// True to check the certificate when connecting using TLS.
+        /// </summary>
+        public bool CertificateCheck { get; set; } = true;
 
         /// <summary>
         /// Constructor
@@ -153,6 +157,10 @@ namespace nanoFramework.M2Mqtt
                 // create SSL stream
                 _sslStream = new SslStream(_socket);
                 _sslStream.UseStoredDeviceCertificate = _clientCert is null;
+                if(!CertificateCheck)
+                {
+                    _sslStream.SslVerification = SslVerification.NoVerification;
+                }
 
                 // server authentication (SSL/TLS handshake)
                 _sslStream.AuthenticateAsClient(_remoteHostName,

--- a/M2Mqtt/Net/MqttNetworkChannel.cs
+++ b/M2Mqtt/Net/MqttNetworkChannel.cs
@@ -71,11 +71,11 @@ namespace nanoFramework.M2Mqtt
         public bool DataAvailable => _secure ? _sslStream.DataAvailable : _socket.Available > 0;
 
         /// <summary>
-        /// True to check the certificate when connecting using TLS.
+        /// True to check the server certificate when connecting using TLS.
         /// Disabling this property will bypass the validation of the server root CA certificate.
         /// Using the library this way it's unsecured and, therefore, not recommended.
         /// </summary>
-        public bool CertificateCheck { get; set; } = true;
+        public bool ValidateServerCertificate { get; set; } = true;
 
         /// <summary>
         /// Constructor
@@ -159,7 +159,7 @@ namespace nanoFramework.M2Mqtt
                 // create SSL stream
                 _sslStream = new SslStream(_socket);
                 _sslStream.UseStoredDeviceCertificate = _clientCert is null;
-                if(!CertificateCheck)
+                if(!ValidateServerCertificate)
                 {
                     _sslStream.SslVerification = SslVerification.NoVerification;
                 }

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ In some cases, it can be handy to avoid the certificate checks when connecting t
 ```csharp
 // You can specify no certificate at all
 MqttClient mqtt = new MqttClient(IoTHub, 8883, true, null, null, MqttSslProtocols.TLSv1_2);
-// And you have to setup the CertificateCheck to false
-mqtt.Settings.CertificateCheck = false;
+// And you have to setup the ValidateServerCertificate to false
+mqtt.Settings.ValidateServerCertificate = false;
 string clientId = Guid.NewGuid().ToString();
 client.Connect(clientId);
 ```

--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ client.Publish("/home/temperature", Encoding.UTF8.GetBytes(strValue), MqttQoSLev
 // More code goes here
 ```
 
+### Avoiding certificate check
+
+In some cases, it can be handy to avoid the certificate checks when connecting through TLS connection. While this scenario is **not** recommended, you can adjust for it like this:
+
+```csharp
+// You can specify no certificate at all
+MqttClient mqtt = new MqttClient(IoTHub, 8883, true, null, null, MqttSslProtocols.TLSv1_2);
+// And you have to setup the CertificateCheck to false
+mqtt.Settings.CertificateCheck = false;
+string clientId = Guid.NewGuid().ToString();
+client.Connect(clientId);
+```
+
 ## Feedback and documentation
 
 For documentation, providing feedback, issues and finding out how to contribute please refer to the [Home repo](https://github.com/nanoframework/Home).

--- a/Tests/MessageUnitTests/MokChannel.cs
+++ b/Tests/MessageUnitTests/MokChannel.cs
@@ -11,7 +11,7 @@ namespace MessageUnitTests
         private byte[] _mokData;
         private int _index = 0;
 
-        public bool CertificateCheck { get; set; }
+        public bool ValidateServerCertificate { get; set; }
 
         public MokChannel(byte[] mokData)
         {

--- a/Tests/MessageUnitTests/MokChannel.cs
+++ b/Tests/MessageUnitTests/MokChannel.cs
@@ -11,6 +11,8 @@ namespace MessageUnitTests
         private byte[] _mokData;
         private int _index = 0;
 
+        public bool CertificateCheck { get; set; }
+
         public MokChannel(byte[] mokData)
         {
             _mokData = mokData;


### PR DESCRIPTION
Adjusting to add an option to avoid certificate checking when connecting using TLS
- Surface the option in the MQTT Client class thru the MqttSettings
- Surface the option in the Mqtt transport class
- Adjusting the Mok class used in test
- Adjusting documentation