### PR TITLE
Revert "Replace `TickCount` with official `TickCount64` (#286)"

### DIFF
--- a/M2Mqtt/Messages/MqttMsgContext.cs
+++ b/M2Mqtt/Messages/MqttMsgContext.cs
@@ -43,7 +43,7 @@ namespace nanoFramework.M2Mqtt.Messages
         /// <summary>
         /// Timestamp in ticks (for retry)
         /// </summary>
-        public long Timestamp { get; set; }
+        public int Timestamp { get; set; }
 
         /// <summary>
         /// Attempt (for retry)

--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -62,7 +62,7 @@ namespace nanoFramework.M2Mqtt
         private AutoResetEvent _keepAliveEvent;
         private AutoResetEvent _keepAliveEventEnd;
         // last communication time in ticks
-        private long _lastCommTime;
+        private int _lastCommTime;
         // channel to communicate over the network
         private IMqttNetworkChannel _channel;
 
@@ -781,7 +781,7 @@ namespace nanoFramework.M2Mqtt
                 _channel.Send(msgBytes);
 
                 // update last message sent ticks
-                _lastCommTime = Environment.TickCount64;
+                _lastCommTime = Environment.TickCount;
             }
             catch (Exception e)
             {
@@ -821,7 +821,7 @@ namespace nanoFramework.M2Mqtt
                 _channel.Send(msgBytes);
 
                 // update last message sent ticks
-                _lastCommTime = Environment.TickCount64;
+                _lastCommTime = Environment.TickCount;
             }
             catch (Exception e)
             {
@@ -982,7 +982,7 @@ namespace nanoFramework.M2Mqtt
                     State = state,
                     Flow = flow,
                     Attempt = 0,
-                    Timestamp = Environment.TickCount64
+                    Timestamp = Environment.TickCount
                 };
 
                 lock (_inflightQueue)
@@ -1401,7 +1401,7 @@ namespace nanoFramework.M2Mqtt
 
                 if (_isRunning)
                 {
-                    delta = (int)(Environment.TickCount64 - _lastCommTime);
+                    delta = Environment.TickCount - _lastCommTime;
 
                     // if timeout exceeded ...
                     if (delta >= _keepAlivePeriod)
@@ -1638,7 +1638,7 @@ namespace nanoFramework.M2Mqtt
                                     // QoS 1, PUBLISH or SUBSCRIBE/UNSUBSCRIBE message to send to broker, state change to wait PUBACK or SUBACK/UNSUBACK                                    
                                     if (msgContext.Flow == MqttMsgFlow.ToPublish)
                                     {
-                                        msgContext.Timestamp = Environment.TickCount64;
+                                        msgContext.Timestamp = Environment.TickCount;
                                         msgContext.Attempt++;
                                         toEnqueue = true;
 
@@ -1709,7 +1709,7 @@ namespace nanoFramework.M2Mqtt
                                     // QoS 2, PUBLISH message to send to broker, state change to wait PUBREC
                                     if (msgContext.Flow == MqttMsgFlow.ToPublish)
                                     {
-                                        msgContext.Timestamp = Environment.TickCount64;
+                                        msgContext.Timestamp = Environment.TickCount;
                                         msgContext.Attempt++;
                                         toEnqueue = true;
 
@@ -1819,7 +1819,7 @@ namespace nanoFramework.M2Mqtt
                                         // current message not acknowledged, no PUBACK or SUBACK/UNSUBACK or not equal messageid 
                                         if (!acknowledge)
                                         {
-                                            delta = (int)(Environment.TickCount64 - msgContext.Timestamp);
+                                            delta = Environment.TickCount - msgContext.Timestamp;
                                             // check timeout for receiving PUBACK since PUBLISH was sent or
                                             // for receiving SUBACK since SUBSCRIBE was sent or
                                             // for receiving UNSUBACK since UNSUBSCRIBE was sent
@@ -1913,7 +1913,7 @@ namespace nanoFramework.M2Mqtt
                                                 };
 
                                                 msgContext.State = MqttMsgState.WaitForPubcomp;
-                                                msgContext.Timestamp = Environment.TickCount64;
+                                                msgContext.Timestamp = Environment.TickCount;
                                                 msgContext.Attempt = 1;
 
                                                 Send(pubrel);
@@ -1932,7 +1932,7 @@ namespace nanoFramework.M2Mqtt
                                         // current message not acknowledged
                                         if (!acknowledge)
                                         {
-                                            delta = (int)(Environment.TickCount64 - msgContext.Timestamp);
+                                            delta = Environment.TickCount - msgContext.Timestamp;
                                             // check timeout for receiving PUBREC since PUBLISH was sent
                                             if (delta >= _settings.DelayOnRetry)
                                             {
@@ -1940,7 +1940,7 @@ namespace nanoFramework.M2Mqtt
                                                 if (msgContext.Attempt < _settings.AttemptsOnRetry)
                                                 {
                                                     msgContext.State = MqttMsgState.QueuedQos2;
-                                                    msgContext.Timestamp = Environment.TickCount64;
+                                                    msgContext.Timestamp = Environment.TickCount;
 
                                                     // re-enqueue message
                                                     lock (_inflightQueue)
@@ -2131,7 +2131,7 @@ namespace nanoFramework.M2Mqtt
                                         // current message not acknowledged
                                         if (!acknowledge)
                                         {
-                                            delta = (int)(Environment.TickCount64 - msgContext.Timestamp);
+                                            delta = Environment.TickCount - msgContext.Timestamp;
                                             // check timeout for receiving PUBCOMP since PUBREL was sent
                                             if (delta >= _settings.DelayOnRetry)
                                             {
@@ -2198,7 +2198,7 @@ namespace nanoFramework.M2Mqtt
                                         };
 
                                         msgContext.State = MqttMsgState.WaitForPubcomp;
-                                        msgContext.Timestamp = Environment.TickCount64;
+                                        msgContext.Timestamp = Environment.TickCount;
                                         msgContext.Attempt++;
                                         // retry ? set dup flag [v3.1.1] no needed
                                         if (ProtocolVersion == MqttProtocolVersion.Version_3_1)

--- a/M2Mqtt/Nanoframework/Environment.cs
+++ b/M2Mqtt/Nanoframework/Environment.cs
@@ -1,0 +1,12 @@
+﻿/*
+Contributors:   
+   .NET Foundation and Contributors - nanoFramework support
+*/
+
+namespace System
+{
+    static class Environment
+    {
+        public static int TickCount => (int)DateTime.UtcNow.Ticks;
+    }
+}

--- a/M2Mqtt/nanoFramework.M2Mqtt.nfproj
+++ b/M2Mqtt/nanoFramework.M2Mqtt.nfproj
@@ -41,6 +41,7 @@
     <Compile Include="Messages\MqttReasonCode.cs" />
     <Compile Include="Messages\MqttRetainHandeling.cs" />
     <Compile Include="Messages\UserProperty.cs" />
+    <Compile Include="nanoFramework\Environment.cs" />
     <Compile Include="Exceptions\MqttClientException.cs" />
     <Compile Include="Exceptions\MqttCommunicationException.cs" />
     <Compile Include="Exceptions\MqttConnectionException.cs" />


### PR DESCRIPTION
This reverts commit f83d6f9abc5977120ec7b56bf6eda02edbcafaea.

<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

## Motivation and Context
- `TickCount64` is causing memory leeks. Needs to be investigated and a deeper rework. See https://discordapp.com/channels/478725473862549535/1033753467916914809/1034000116199194696


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
