### PR TITLE
Add new `Publish` method accepting user properties

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -264,6 +264,10 @@ namespace nanoFramework.M2Mqtt
         /// </summary>
         public MqttSettings Settings => _settings;
 
+        internal MqttClient()
+        {
+            // empty constructor, required for Unit Tests
+        }
 
         /// <summary>
         /// Constructor
@@ -676,6 +680,7 @@ namespace nanoFramework.M2Mqtt
                 topic,
                 message,
                 null,
+                null,
                 MqttQoSLevel.AtMostOnce,
                 false);
         }
@@ -696,33 +701,60 @@ namespace nanoFramework.M2Mqtt
                 topic,
                 message,
                 contentType,
+                null,
                 MqttQoSLevel.AtMostOnce,
                 false);
         }
 
+        /// <summary>
+        /// Publish a message asynchronously (QoS Level <see cref="MqttQoSLevel.AtMostOnce"/> and not retained).
+        /// </summary>
+        /// <param name="topic">Message topic.</param>
+        /// <param name="message">Message data (payload).</param>
+        /// <param name="contentType">Content of the application message. This is only available for MQTT v5.0.</param>
+        /// <param name="userProperties">User properties for the application message. This is only available for MQTT v5.0</param>
+        /// <returns>Message Id related to PUBLISH message.</returns>
+        /// <exception cref="ArgumentException">If <paramref name="userProperties"/> elements aren't of type <see cref="UserProperty"/>.</exception>
+        public ushort Publish(
+            string topic,
+            byte[] message,
+            string contentType,
+            ArrayList userProperties)
+        {
+            return Publish(
+                topic,
+                message,
+                contentType,
+                userProperties,
+                MqttQoSLevel.AtMostOnce,
+                false);
+        }
         /// <summary>
         /// Publish a message asynchronously.
         /// </summary>
         /// <param name="topic">Message topic.</param>
         /// <param name="message">Message data (payload).</param>
         /// <param name="contentType">Content of the application message. This is only available for MQTT v5.0.</param>
+        /// <param name="userProperties">User properties for the application message. This is only available for MQTT v5.0</param>
         /// <param name="qosLevel">QoS Level.</param>
         /// <param name="retain">Retain flag.</param>
         /// <returns>Message Id related to PUBLISH message.</returns>
+        /// <exception cref="ArgumentException">If <paramref name="userProperties"/> elements aren't of type <see cref="UserProperty"/>.</exception>
         public ushort Publish(
             string topic,
             byte[] message,
             string contentType,
+            ArrayList userProperties,
             MqttQoSLevel qosLevel,
             bool retain)
         {
-            MqttMsgPublish publish =
-                    new MqttMsgPublish(topic, message, false, qosLevel, retain)
-                    {
-                        MessageId = GetMessageId()
-                    };
-
-            publish.ContentType = contentType;
+            MqttMsgPublish publish = ComposeMqttMsgPublish(
+                topic,
+                message,
+                contentType,
+                userProperties,
+                qosLevel,
+                retain);
 
             // enqueue message to publish into the inflight queue
             if (publish.QosLevel != MqttQoSLevel.AtMostOnce)
@@ -2454,6 +2486,47 @@ namespace nanoFramework.M2Mqtt
                         msgCtx.Flow == Flow);
 
             }
+        }
+
+        internal MqttMsgPublish ComposeMqttMsgPublish(
+            string topic,
+            byte[] message,
+            string contentType,
+            ArrayList userProperties,
+            MqttQoSLevel qosLevel,
+            bool retain)
+        {
+
+            MqttMsgPublish mqttMsgPublish = new(
+                topic,
+                message,
+                false,
+                qosLevel,
+                retain)
+            {
+                MessageId = GetMessageId()
+            };
+
+            mqttMsgPublish.ContentType = contentType;
+
+            if (userProperties != null
+                && userProperties.Count > 0)
+            {
+                // performs validation of collection items
+                foreach (var property in userProperties)
+                {
+                    if (!property.GetType().Equals(typeof(UserProperty)))
+                    {
+#pragma warning disable S3928 // OK to use this in .NET nanoFramework without the argument name
+                        throw new ArgumentException();
+#pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one 
+                    }
+                }
+
+                mqttMsgPublish.UserProperties = userProperties;
+            }
+
+            return mqttMsgPublish;
         }
     }
 

--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -715,6 +715,7 @@ namespace nanoFramework.M2Mqtt
         /// <param name="userProperties">User properties for the application message. This is only available for MQTT v5.0</param>
         /// <returns>Message Id related to PUBLISH message.</returns>
         /// <exception cref="ArgumentException">If <paramref name="userProperties"/> elements aren't of type <see cref="UserProperty"/>.</exception>
+        /// <exception cref="NotSupportedException">If setting a parameter that is not supported in the MQTT version set for this <see cref="MqttClient"/>.</exception>
         public ushort Publish(
             string topic,
             byte[] message,
@@ -740,6 +741,7 @@ namespace nanoFramework.M2Mqtt
         /// <param name="retain">Retain flag.</param>
         /// <returns>Message Id related to PUBLISH message.</returns>
         /// <exception cref="ArgumentException">If <paramref name="userProperties"/> elements aren't of type <see cref="UserProperty"/>.</exception>
+        /// <exception cref="NotSupportedException">If setting a parameter that is not supported in the MQTT version set for this <see cref="MqttClient"/>.</exception>
         public ushort Publish(
             string topic,
             byte[] message,
@@ -2509,9 +2511,14 @@ namespace nanoFramework.M2Mqtt
 
             mqttMsgPublish.ContentType = contentType;
 
-            if (userProperties != null
-                && userProperties.Count > 0)
+            if (userProperties != null)
             {
+                if (ProtocolVersion < MqttProtocolVersion.Version_5)
+                {
+                    // user properties are only supported in v5
+                    throw new NotSupportedException();
+                }
+
                 // performs validation of collection items
                 foreach (var property in userProperties)
                 {

--- a/M2Mqtt/Properties/AssemblyInfo.cs
+++ b/M2Mqtt/Properties/AssemblyInfo.cs
@@ -33,3 +33,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyNativeVersion("0.0.0.0")]
 ///////////////////////////////////////////////////
 
+[assembly: InternalsVisibleTo("NFUnitTest, PublicKey=" + "00240000048000009400000006020000002400005253413100040000010001001120aa3e809b3d" +
+"a4f65e1b1f65c0a3a1bf6335c39860ca41acb3c48de278c6b63c5df38239ec1f2e32d58cb897c8" +
+"c174a5f8e78a9c0b6087d3aef373d7d0f3d9be67700fc2a5a38de1fb71b5b6f6046d841ff35abe" +
+"e2e0b0840a6291a312be184eb311baff5fef0ff6895b9a5f2253aed32fb06b819134f6bb9d5314" +
+"88a87ea2")]

--- a/Tests/MessageUnitTests/MessageUnitTests.nfproj
+++ b/Tests/MessageUnitTests/MessageUnitTests.nfproj
@@ -26,6 +26,15 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\..\M2Mqtt\key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+  <PropertyGroup>
     <RunSettingsFilePath>$(MSBuildProjectDirectory)\nano.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <ItemGroup>

--- a/Tests/MessageUnitTests/PublishTests.cs
+++ b/Tests/MessageUnitTests/PublishTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections;
 using System.Text;
 using nanoFramework.M2Mqtt;
 using nanoFramework.M2Mqtt.Exceptions;
@@ -80,6 +82,100 @@ namespace MessageUnitTests
             // Assert
             Assert.Equal(encodedCorrect, encoded);
         }
+
+        [TestMethod]
+        public void PublishUserPropertiesTest()
+        {
+            // Can't call Publish() because it will try to enqueue the message and this will fail.
+            // Instead call ComposeMqttMsgPublish() which will be calling the constructor and perform the validations.
+
+            // Arrange
+            var client = new MqttClient();
+
+            OutputHelper.WriteLine("");
+            OutputHelper.WriteLine("== Testing Publish with user properties. ==");
+            OutputHelper.WriteLine("");
+
+            // OK adding a null to user properties
+            OutputHelper.WriteLine("Adding a null to user properties collection.");
+
+            _ = client.ComposeMqttMsgPublish(
+                Topic,
+                Encoding.UTF8.GetBytes(MessageString),
+                null,
+                null,
+                MqttQoSLevel.ExactlyOnce,
+                false);
+
+            // OK adding an empty collection to user properties
+            OutputHelper.WriteLine("Adding an empty collection to user properties collection.");
+
+            _ = client.ComposeMqttMsgPublish(
+                Topic,
+                Encoding.UTF8.GetBytes(MessageString),
+                null,
+                new ArrayList(),
+                MqttQoSLevel.ExactlyOnce,
+                false);
+
+            // add invalid user properties
+            OutputHelper.WriteLine("Adding a collection of strings to user properties collection, which is not valid.");
+
+            Assert.Throws(typeof(ArgumentException), () =>
+            {
+                _ = client.ComposeMqttMsgPublish(
+                    Topic,
+                    Encoding.UTF8.GetBytes(MessageString),
+                    null,
+                    new ArrayList()
+                    {
+                        "I'm a fake user property",
+                        "I'm another fake user property"
+                    },
+                    MqttQoSLevel.ExactlyOnce,
+                    false);
+            },
+            "Adding array of strings to user properties should throw ArgumentException."
+            );
+
+            // add invalid user properties
+            OutputHelper.WriteLine("Adding a collection of integers to user properties collection, which is not valid.");
+
+            Assert.Throws(typeof(ArgumentException), () =>
+            {
+                _ = client.ComposeMqttMsgPublish(
+                    Topic,
+                    Encoding.UTF8.GetBytes(MessageString),
+                    null,
+                    new ArrayList()
+                    {
+                        777,
+                        888,
+                        999
+                    },
+                    MqttQoSLevel.ExactlyOnce,
+                    false
+                    );
+            },
+            "Adding array of integers to user properties should throw ArgumentException."
+            );
+
+            // add proper user properties
+            OutputHelper.WriteLine("Adding a valid collection of user properties.");
+
+            _ = client.ComposeMqttMsgPublish(
+                Topic,
+                Encoding.UTF8.GetBytes(MessageString),
+                null,
+                new ArrayList()
+                {
+                    new UserProperty("property1", "property1_value"),
+                    new UserProperty("property2", "property2_value")
+                },
+                MqttQoSLevel.ExactlyOnce,
+                false);
+        }
+
 
         [TestMethod]
         public void PublishAdvancedEncodeTestv5_00()


### PR DESCRIPTION
## Description
- Add new parameter to Publish methods.
- Extract constructor for MqttMsgPublish.
- Add validation of type for user properties array.
- Internals of M2Mqtt are now accessible to unit test projects.
- Add strong key signing to unit test project (required to access internals of Mqtt assembly.
- Add unit test for Publish methods validating user properties parameter.

## Motivation and Context
- Exposes user properties in `Publish` methods, allowing callers to easily set it.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
