### PR TITLE
Fix CONNECT with will flag

### DIFF
--- a/M2Mqtt/Messages/MqttMsgConnect.cs
+++ b/M2Mqtt/Messages/MqttMsgConnect.cs
@@ -530,6 +530,8 @@ namespace nanoFramework.M2Mqtt.Messages
 
             // client identifier field size
             payloadSize += clientIdUtf8.Length + 2;
+            // will properties field size (not supported at this time, but the will properties count must be present)
+            payloadSize += WillFlag ? 2 : 0;
             // will topic field size
             payloadSize += (willTopicUtf8 != null) ? (willTopicUtf8.Length + 2) : 0;
             // will message field size
@@ -668,6 +670,12 @@ namespace nanoFramework.M2Mqtt.Messages
             buffer[index++] = (byte)(clientIdUtf8.Length & 0x00FF); // LSB
             Array.Copy(clientIdUtf8, 0, buffer, index, clientIdUtf8.Length);
             index += clientIdUtf8.Length;
+
+            // will properties (not supported but need to be present if will flag is set. See 3.1.3.2 Will Properties and [MQTT-3.1.2-9])
+            if (WillFlag)
+            {
+                index = EncodeVariableByte(0, buffer, index);
+            }
 
             // will topic
             if (WillFlag && (willTopicUtf8 != null))


### PR DESCRIPTION
- Add missing will properties to payload.

<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

## Motivation and Context
- When setting the Will Flag, Will properties have to be included in the payload. Despite we're not supporting these currently. See [3.1.3.2 Will Properties](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901060) and [MQTT-3.1.2-9](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901292).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Connecting to Azure Event grid specifying will topic and will message.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.

cc @sandervandevelde
